### PR TITLE
Remove redundant InitializeComponent overrides for cleanup.

### DIFF
--- a/EngineSIU/EngineSIU/Engine/Source/Runtime/Engine/Classes/Components/BillboardComponent.cpp
+++ b/EngineSIU/EngineSIU/Engine/Source/Runtime/Engine/Classes/Components/BillboardComponent.cpp
@@ -63,12 +63,6 @@ void UBillboardComponent::SetProperties(const TMap<FString, FString>& InProperti
     }
 }
 
-void UBillboardComponent::InitializeComponent()
-{
-    Super::InitializeComponent();
-
-}
-
 void UBillboardComponent::TickComponent(float DeltaTime)
 {
     Super::TickComponent(DeltaTime);

--- a/EngineSIU/EngineSIU/Engine/Source/Runtime/Engine/Classes/Components/BillboardComponent.h
+++ b/EngineSIU/EngineSIU/Engine/Source/Runtime/Engine/Classes/Components/BillboardComponent.h
@@ -15,7 +15,6 @@ public:
     virtual UObject* Duplicate(UObject* InOuter) override;
     virtual void GetProperties(TMap<FString, FString>& OutProperties) const override;
     virtual void SetProperties(const TMap<FString, FString>& InProperties) override;
-    virtual void InitializeComponent() override;
     virtual void TickComponent(float DeltaTime) override;
     virtual int CheckRayIntersection(
         FVector& rayOrigin,

--- a/EngineSIU/EngineSIU/Engine/Source/Runtime/Engine/Classes/Components/LuaScriptComponent.cpp
+++ b/EngineSIU/EngineSIU/Engine/Source/Runtime/Engine/Classes/Components/LuaScriptComponent.cpp
@@ -26,6 +26,11 @@ UObject* ULuaScriptComponent::Duplicate(UObject* InOuter)
 
 void ULuaScriptComponent::InitializeComponent()
 {
+    if (HasBeenInitialized())
+    {
+        return;
+    }
+    Super::InitializeComponent();
     if (ScriptName.IsEmpty())
     {
         if (GetWorld() && GetWorld()->GetActiveLevel())
@@ -73,7 +78,7 @@ void ULuaScriptComponent::EndPlay(const EEndPlayReason::Type EndPlayReason)
 
 void ULuaScriptComponent::DestroyComponent(bool bPromoteChildren)
 {
-    //FLuaScriptManager::Get().UnRigisterActiveLuaComponent(this);
+    FLuaScriptManager::Get().UnRigisterActiveLuaComponent(this);
     Super::DestroyComponent(bPromoteChildren);
 }
 

--- a/EngineSIU/EngineSIU/Engine/Source/Runtime/Engine/Classes/Components/PrimitiveComponent.cpp
+++ b/EngineSIU/EngineSIU/Engine/Source/Runtime/Engine/Classes/Components/PrimitiveComponent.cpp
@@ -11,11 +11,6 @@ UObject* UPrimitiveComponent::Duplicate(UObject* InOuter)
     return NewComponent;
 }
 
-void UPrimitiveComponent::InitializeComponent()
-{
-    Super::InitializeComponent();
-}
-
 void UPrimitiveComponent::TickComponent(float DeltaTime)
 {
     Super::TickComponent(DeltaTime);

--- a/EngineSIU/EngineSIU/Engine/Source/Runtime/Engine/Classes/Components/PrimitiveComponent.h
+++ b/EngineSIU/EngineSIU/Engine/Source/Runtime/Engine/Classes/Components/PrimitiveComponent.h
@@ -10,7 +10,6 @@ public:
     UPrimitiveComponent() = default;
 
     virtual UObject* Duplicate(UObject* InOuter) override;
-    virtual void InitializeComponent() override;
     virtual void TickComponent(float DeltaTime) override;
     virtual int CheckRayIntersection(FVector& rayOrigin, FVector& rayDirection, float& pfNearHitDistance) override;
 

--- a/EngineSIU/EngineSIU/Engine/Source/Runtime/Engine/Classes/Components/SceneComponent.cpp
+++ b/EngineSIU/EngineSIU/Engine/Source/Runtime/Engine/Classes/Components/SceneComponent.cpp
@@ -62,12 +62,6 @@ void USceneComponent::SetProperties(const TMap<FString, FString>& InProperties)
     }
 }
 
-void USceneComponent::InitializeComponent()
-{
-    Super::InitializeComponent();
-
-}
-
 void USceneComponent::TickComponent(float DeltaTime)
 {
 	Super::TickComponent(DeltaTime);

--- a/EngineSIU/EngineSIU/Engine/Source/Runtime/Engine/Classes/Components/SceneComponent.h
+++ b/EngineSIU/EngineSIU/Engine/Source/Runtime/Engine/Classes/Components/SceneComponent.h
@@ -16,7 +16,6 @@ public:
     void GetProperties(TMap<FString, FString>& OutProperties) const override;
     void SetProperties(const TMap<FString, FString>& InProperties) override;
 
-    virtual void InitializeComponent() override;
     virtual void TickComponent(float DeltaTime) override;
     virtual int CheckRayIntersection(FVector& InRayOrigin, FVector& InRayDirection, float& pfNearHitDistance);
     virtual void DestroyComponent(bool bPromoteChildren = false) override;

--- a/EngineSIU/EngineSIU/Engine/Source/Runtime/Engine/Classes/Components/SphereComp.cpp
+++ b/EngineSIU/EngineSIU/Engine/Source/Runtime/Engine/Classes/Components/SphereComp.cpp
@@ -10,11 +10,6 @@ USphereComp::USphereComp()
     AABB.min = {-1, -1, -1};
 }
 
-void USphereComp::InitializeComponent()
-{
-    Super::InitializeComponent();
-}
-
 void USphereComp::TickComponent(float DeltaTime)
 {
     Super::TickComponent(DeltaTime);

--- a/EngineSIU/EngineSIU/Engine/Source/Runtime/Engine/Classes/Components/SphereComp.h
+++ b/EngineSIU/EngineSIU/Engine/Source/Runtime/Engine/Classes/Components/SphereComp.h
@@ -8,7 +8,6 @@ class USphereComp : public UStaticMeshComponent
 
 public:
     USphereComp();
-
-    virtual void InitializeComponent() override;
+    
     virtual void TickComponent(float DeltaTime) override;
 };

--- a/EngineSIU/EngineSIU/Engine/Source/Runtime/Engine/Classes/Components/TextComponent.cpp
+++ b/EngineSIU/EngineSIU/Engine/Source/Runtime/Engine/Classes/Components/TextComponent.cpp
@@ -74,11 +74,6 @@ void UTextComponent::SetProperties(const TMap<FString, FString>& InProperties)
     
 }
 
-void UTextComponent::InitializeComponent()
-{
-    Super::InitializeComponent();
-}
-
 void UTextComponent::TickComponent(float DeltaTime)
 {
     Super::TickComponent(DeltaTime);

--- a/EngineSIU/EngineSIU/Engine/Source/Runtime/Engine/Classes/Components/TextComponent.h
+++ b/EngineSIU/EngineSIU/Engine/Source/Runtime/Engine/Classes/Components/TextComponent.h
@@ -17,8 +17,6 @@ public:
     void GetProperties(TMap<FString, FString>& OutProperties) const override;
     
     void SetProperties(const TMap<FString, FString>& InProperties) override;
-
-    virtual void InitializeComponent() override;
     
     virtual void TickComponent(float DeltaTime) override;
     

--- a/EngineSIU/EngineSIU/Engine/Source/Runtime/Engine/Classes/GameFramework/Actor.cpp
+++ b/EngineSIU/EngineSIU/Engine/Source/Runtime/Engine/Classes/GameFramework/Actor.cpp
@@ -264,10 +264,7 @@ void AActor::InitializeComponents()
             ActorComp->Activate();
         }
 
-        if (!ActorComp->HasBeenInitialized())
-        {
-            ActorComp->InitializeComponent();
-        }
+        ActorComp->InitializeComponent();
     }
 }
 

--- a/EngineSIU/EngineSIU/Engine/Source/Runtime/Engine/Classes/Level.cpp
+++ b/EngineSIU/EngineSIU/Engine/Source/Runtime/Engine/Classes/Level.cpp
@@ -1,6 +1,7 @@
 #include "Level.h"
 #include "GameFramework/Actor.h"
 #include "UObject/Casts.h"
+#include "World/World.h"
 
 
 void ULevel::InitLevel(UWorld* InOwningWorld)
@@ -11,15 +12,11 @@ void ULevel::InitLevel(UWorld* InOwningWorld)
 
 void ULevel::Release()
 {
-    for (AActor* Actor : Actors)
+    const auto CopiedActors = Actors;
+    for (AActor* Actor : CopiedActors)
     {
         Actor->EndPlay(EEndPlayReason::WorldTransition);
-        TSet<UActorComponent*> Components = Actor->GetComponents();
-        for (UActorComponent* Component : Components)
-        {
-            GUObjectArray.MarkRemoveObject(Component);
-        }
-        GUObjectArray.MarkRemoveObject(Actor);
+        OwningWorld->DestroyActor(Actor);
     }
     Actors.Empty();
 }

--- a/EngineSIU/EngineSIU/Engine/Source/Runtime/Engine/World/World.cpp
+++ b/EngineSIU/EngineSIU/Engine/Source/Runtime/Engine/World/World.cpp
@@ -148,7 +148,6 @@ bool UWorld::DestroyActor(AActor* ThisActor)
     {
         EditorEngine->DeselectActor(ThisActor);
     }
-
     if (EditorEngine->GetSelectedComponent() && ThisActor->GetComponentByFName<UActorComponent>(EditorEngine->GetSelectedComponent()->GetFName()))
     {
         EditorEngine->DeselectComponent(EditorEngine->GetSelectedComponent());

--- a/EngineSIU/EngineSIU/Engine/Source/Runtime/InteractiveToolsFramework/BaseGizmos/GizmoArrowComponent.cpp
+++ b/EngineSIU/EngineSIU/Engine/Source/Runtime/InteractiveToolsFramework/BaseGizmos/GizmoArrowComponent.cpp
@@ -1,11 +1,6 @@
 #include "GizmoArrowComponent.h"
 
 
-void UGizmoArrowComponent::InitializeComponent()
-{
-    Super::InitializeComponent();
-}
-
 void UGizmoArrowComponent::TickComponent(float DeltaTime)
 {
     Super::TickComponent(DeltaTime);

--- a/EngineSIU/EngineSIU/Engine/Source/Runtime/InteractiveToolsFramework/BaseGizmos/GizmoArrowComponent.h
+++ b/EngineSIU/EngineSIU/Engine/Source/Runtime/InteractiveToolsFramework/BaseGizmos/GizmoArrowComponent.h
@@ -10,7 +10,6 @@ class UGizmoArrowComponent : public UGizmoBaseComponent
 public:
     UGizmoArrowComponent() = default;
 
-    virtual void InitializeComponent() override;
     virtual void TickComponent(float DeltaTime) override;
 
 private:

--- a/EngineSIU/EngineSIU/Engine/Source/Runtime/InteractiveToolsFramework/BaseGizmos/GizmoRectangleComponent.cpp
+++ b/EngineSIU/EngineSIU/Engine/Source/Runtime/InteractiveToolsFramework/BaseGizmos/GizmoRectangleComponent.cpp
@@ -1,11 +1,6 @@
 #include "GizmoRectangleComponent.h"
 
 
-void UGizmoRectangleComponent::InitializeComponent()
-{
-    Super::InitializeComponent();
-}
-
 void UGizmoRectangleComponent::TickComponent(float DeltaTime)
 {
     Super::TickComponent(DeltaTime);

--- a/EngineSIU/EngineSIU/Engine/Source/Runtime/InteractiveToolsFramework/BaseGizmos/GizmoRectangleComponent.h
+++ b/EngineSIU/EngineSIU/Engine/Source/Runtime/InteractiveToolsFramework/BaseGizmos/GizmoRectangleComponent.h
@@ -8,7 +8,5 @@ class UGizmoRectangleComponent : public UGizmoBaseComponent
 
 public:
     UGizmoRectangleComponent() = default;
-
-    virtual void InitializeComponent() override;
     virtual void TickComponent(float DeltaTime) override;
 };

--- a/EngineSIU/EngineSIU/Engine/Source/Runtime/Launch/EngineLoop.cpp
+++ b/EngineSIU/EngineSIU/Engine/Source/Runtime/Launch/EngineLoop.cpp
@@ -182,7 +182,9 @@ void FEngineLoop::Tick()
         }
 
         if (LuaScriptManager)
+        {
             LuaScriptManager->HotReloadLuaScript();
+        }
 
         GraphicDevice.SwapBuffer();
         do

--- a/EngineSIU/EngineSIU/Saved/DefaultLevel.scene
+++ b/EngineSIU/EngineSIU/Saved/DefaultLevel.scene
@@ -37,57 +37,6 @@
                         "bAutoActive": "true",
                         "bIsActive": "true"
                     }
-                },
-                {
-
-                    "ComponentClass": "UStaticMeshComponent",
-                    "ComponentID": "StaticMeshComponent_0",
-                    "Properties": {
-                        "AABB_max": "X=1.287 Y=1.199 Z=2.555",
-                        "AABB_min": "X=-1.287 Y=-1.199 Z=-0.000",
-                        "AttachParentID": "nullptr",
-                        "ComponentClass": "UStaticMeshComponent",
-                        "ComponentName": "StaticMeshComponent_0",
-
-                        "ComponentOwner": "ACube_124",
-                        "ComponentOwnerClass": "ACube",
-                        "RelativeLocation": "X=0.000 Y=-7.326 Z=0.000",
-
-                        "RelativeRotation": "Pitch=0.000 Yaw=0.000 Roll=0.000",
-                        "RelativeScale3D": "X=1.000 Y=1.000 Z=1.000",
-                        "StaticMeshPath": "Contents/Reference/Reference.obj",
-                        "bAutoActive": "true",
-                        "bIsActive": "true",
-                        "m_Type": ""
-                    }
-                },
-                {
-                    "ComponentClass": "ULuaScriptComponent",
-                    "ComponentID": "LuaComponent_0",
-                    "Properties": {
-                        "ComponentClass": "ULuaScriptComponent",
-                        "ComponentName": "LuaComponent_0",
-
-                        "ComponentOwner": "ACube_124",
-
-                        "ComponentOwnerClass": "ACube",
-                        "bAutoActive": "true",
-                        "bIsActive": "true"
-                    }
-                },
-                {
-
-                    "ComponentClass": "ULuaScriptComponent",
-                    "ComponentID": "ULuaScriptComponent_130",
-                    "Properties": {
-                        "ComponentClass": "ULuaScriptComponent",
-                        "ComponentName": "ULuaScriptComponent_130",
-                        "ComponentOwner": "ACube_124",
-                        "ComponentOwnerClass": "ACube",
-                        "bAutoActive": "true",
-                        "bIsActive": "true"
-
-                    }
                 }
             ],
             "Properties": {
@@ -149,7 +98,6 @@
                     }
                 },
                 {
-
                     "ComponentClass": "ULuaScriptComponent",
                     "ComponentID": "LuaComponent_0",
                     "Properties": {
@@ -157,8 +105,7 @@
                         "ComponentName": "LuaComponent_0",
                         "ComponentOwner": "ACharacter_133",
                         "ComponentOwnerClass": "ACharacter",
-                        "bAutoActive": "true",
-
+                        "bAutoActive": "true"
                     }
                 }
             ],


### PR DESCRIPTION
The `InitializeComponent` method overrides were removed where unnecessary, relying on the default behavior from the base class. This reduces duplicate code and simplifies component initialization logic across multiple files. Additional improvements include Lua script management refinements and actor destruction handling for better modularity and maintainability.