### PR TITLE
Transform

### DIFF
--- a/EngineSIU/EngineSIU/Engine/Source/Editor/LevelEditor/SLevelEditor.cpp
+++ b/EngineSIU/EngineSIU/Engine/Source/Editor/LevelEditor/SLevelEditor.cpp
@@ -90,21 +90,32 @@ void SLevelEditor::Initialize(uint32 InEditorWidth, uint32 InEditorHeight)
         {
             if (const UEditorEngine* EdEngine = Cast<UEditorEngine>(GEngine))
             {
-                if (const AActor* SelectedActor = EdEngine->GetSelectedActor())
+                USceneComponent* TargetComponent = nullptr;
+                if (USceneComponent* SelectedComponent = EdEngine->GetSelectedComponent())
                 {
-                    // 초기 Actor와 Cursor의 거리차를 저장
-                    const FViewportCamera* ViewTransform = ActiveViewportClient->GetViewportType() == LVT_Perspective
-                                                        ? &ActiveViewportClient->GetPerspectiveCamera()
-                                                        : &ActiveViewportClient->GetOrthogonalCamera();
-
-                    FVector RayOrigin, RayDir;
-                    ActiveViewportClient->DeprojectFVector2D(FWindowsCursor::GetClientPosition(), RayOrigin, RayDir);
-
-                    const FVector TargetLocation = SelectedActor->GetActorLocation();
-                    const float TargetDist = FVector::Distance(ViewTransform->GetLocation(), TargetLocation);
-                    const FVector TargetRayEnd = RayOrigin + RayDir * TargetDist;
-                    TargetDiff = TargetLocation - TargetRayEnd;
+                    TargetComponent = SelectedComponent;
                 }
+                else if (AActor* SelectedActor = EdEngine->GetSelectedActor())
+                {
+                    TargetComponent = SelectedActor->GetRootComponent();
+                }
+                else
+                {
+                    return;
+                }
+
+                // 초기 Actor와 Cursor의 거리차를 저장
+                const FViewportCamera* ViewTransform = ActiveViewportClient->GetViewportType() == LVT_Perspective
+                                                    ? &ActiveViewportClient->GetPerspectiveCamera()
+                                                    : &ActiveViewportClient->GetOrthogonalCamera();
+
+                FVector RayOrigin, RayDir;
+                ActiveViewportClient->DeprojectFVector2D(FWindowsCursor::GetClientPosition(), RayOrigin, RayDir);
+
+                const FVector TargetLocation = TargetComponent->GetWorldLocation();
+                const float TargetDist = FVector::Distance(ViewTransform->GetLocation(), TargetLocation);
+                const FVector TargetRayEnd = RayOrigin + RayDir * TargetDist;
+                TargetDiff = TargetLocation - TargetRayEnd;     
             }
             break;
         }
@@ -230,92 +241,91 @@ void SLevelEditor::Initialize(uint32 InEditorWidth, uint32 InEditorHeight)
         )
         {
             // 에디터 카메라 이동 로직
-            if (
-                !InMouseEvent.IsMouseButtonDown(EKeys::LeftMouseButton)
-                && InMouseEvent.IsMouseButtonDown(EKeys::RightMouseButton)
-            )
+            if (!InMouseEvent.IsMouseButtonDown(EKeys::LeftMouseButton) && InMouseEvent.IsMouseButtonDown(EKeys::RightMouseButton))
             {
                 ActiveViewportClient->MouseMove(InMouseEvent);
             }
-
-            else if (
-                !InMouseEvent.IsMouseButtonDown(EKeys::RightMouseButton)
-                && InMouseEvent.IsMouseButtonDown(EKeys::LeftMouseButton)
-            )
+            else if (!InMouseEvent.IsMouseButtonDown(EKeys::RightMouseButton) && InMouseEvent.IsMouseButtonDown(EKeys::LeftMouseButton))
             {
+                // Gizmo control
                 if (const UEditorEngine* EdEngine = Cast<UEditorEngine>(GEngine))
                 {
-                    if (AActor* SelectedActor = EdEngine->GetSelectedActor())
+                    const UGizmoBaseComponent* Gizmo = Cast<UGizmoBaseComponent>(ActiveViewportClient->GetPickedGizmoComponent());
+                    if (!Gizmo)
                     {
-                        // TODO: 추후 Component를 이동하는걸로 바꾸기
-                        if (const UGizmoBaseComponent* Gizmo = Cast<UGizmoBaseComponent>(ActiveViewportClient->GetPickedGizmoComponent()))
+                        return;
+                    }
+                    
+                    USceneComponent* TargetComponent = EdEngine->GetSelectedComponent();
+                    if (!TargetComponent)
+                    {
+                        if (AActor* SelectedActor = EdEngine->GetSelectedActor())
                         {
-                            const FViewportCamera* ViewTransform = ActiveViewportClient->GetViewportType() == LVT_Perspective
-                                                        ? &ActiveViewportClient->GetPerspectiveCamera()
-                                                        : &ActiveViewportClient->GetOrthogonalCamera();
-
-                            FVector RayOrigin, RayDir;
-                            ActiveViewportClient->DeprojectFVector2D(FWindowsCursor::GetClientPosition(), RayOrigin, RayDir);
-                            const float TargetDist = FVector::Distance(ViewTransform->GetLocation(), SelectedActor->GetActorLocation());
-                            const FVector TargetRayEnd = RayOrigin + RayDir * TargetDist;
-                            const FVector Result = TargetRayEnd + TargetDiff;
-
-                            if (EdEngine->GetEditorPlayer()->GetCoordMode() == CDM_WORLD)
-                            {
-                                // 월드 좌표계에서 카메라 방향을 고려한 이동
-                                if (Gizmo->GetGizmoType() == UGizmoBaseComponent::ArrowX)
-                                {
-                                    // 카메라의 오른쪽 방향을 X축 이동에 사용
-                                    FVector NewLocation = SelectedActor->GetActorLocation();
-                                    NewLocation.X = Result.X;
-                                    SelectedActor->SetActorLocation(NewLocation);
-                                }
-                                else if (Gizmo->GetGizmoType() == UGizmoBaseComponent::ArrowY)
-                                {
-                                    // 카메라의 오른쪽 방향을 Y축 이동에 사용
-                                    FVector NewLocation = SelectedActor->GetActorLocation();
-                                    NewLocation.Y = Result.Y;
-                                    SelectedActor->SetActorLocation(NewLocation);
-                                }
-                                else if (Gizmo->GetGizmoType() == UGizmoBaseComponent::ArrowZ)
-                                {
-                                    // 카메라의 위쪽 방향을 Z축 이동에 사용
-                                    FVector NewLocation = SelectedActor->GetActorLocation();
-                                    NewLocation.Z = Result.Z;
-                                    SelectedActor->SetActorLocation(NewLocation);
-                                }
-                            }
-                            else
-                            {
-                                // Result에서 현재 액터 위치를 빼서 이동 벡터를 구함
-                                const FVector Delta = Result - SelectedActor->GetActorLocation();
-
-                                // 각 축에 대해 Local 방향 벡터에 투영하여 이동량 계산
-                                if (Gizmo->GetGizmoType() == UGizmoBaseComponent::ArrowX)
-                                {
-                                    const float MoveAmount = FVector::DotProduct(Delta, SelectedActor->GetActorForwardVector());
-                                    const FVector NewLocation = SelectedActor->GetActorLocation() + SelectedActor->GetActorForwardVector() * MoveAmount;
-                                    SelectedActor->SetActorLocation(NewLocation);
-                                }
-                                else if (Gizmo->GetGizmoType() == UGizmoBaseComponent::ArrowY)
-                                {
-                                    const float MoveAmount = FVector::DotProduct(Delta, SelectedActor->GetActorRightVector());
-                                    const FVector NewLocation = SelectedActor->GetActorLocation() + SelectedActor->GetActorRightVector() * MoveAmount;
-                                    SelectedActor->SetActorLocation(NewLocation);
-                                }
-                                else if (Gizmo->GetGizmoType() == UGizmoBaseComponent::ArrowZ)
-                                {
-                                    const float MoveAmount = FVector::DotProduct(Delta, SelectedActor->GetActorUpVector());
-                                    const FVector NewLocation = SelectedActor->GetActorLocation() + SelectedActor->GetActorUpVector() * MoveAmount;
-                                    SelectedActor->SetActorLocation(NewLocation);
-                                }
-                            }
+                            TargetComponent = SelectedActor->GetRootComponent();
+                        }
+                        else
+                        {
+                            return;
                         }
                     }
+
+                    const FViewportCamera* ViewTransform = ActiveViewportClient->GetViewportType() == LVT_Perspective
+                                                            ? &ActiveViewportClient->GetPerspectiveCamera()
+                                                            : &ActiveViewportClient->GetOrthogonalCamera();
+                        
+                    FVector RayOrigin, RayDir;
+                    ActiveViewportClient->DeprojectFVector2D(FWindowsCursor::GetClientPosition(), RayOrigin, RayDir);
+
+                    const float TargetDist = FVector::Distance(ViewTransform->GetLocation(), TargetComponent->GetWorldLocation());
+                    const FVector TargetRayEnd = RayOrigin + RayDir * TargetDist;
+                    const FVector Result = TargetRayEnd + TargetDiff;
+
+                    FVector NewLocation = TargetComponent->GetWorldLocation();
+                    if (EdEngine->GetEditorPlayer()->GetCoordMode() == CDM_WORLD)
+                    {
+                        // 월드 좌표계에서 카메라 방향을 고려한 이동
+                        if (Gizmo->GetGizmoType() == UGizmoBaseComponent::ArrowX)
+                        {
+                            // 카메라의 오른쪽 방향을 X축 이동에 사용
+                            NewLocation.X = Result.X;
+                        }
+                        else if (Gizmo->GetGizmoType() == UGizmoBaseComponent::ArrowY)
+                        {
+                            // 카메라의 오른쪽 방향을 Y축 이동에 사용
+                            NewLocation.Y = Result.Y;
+                        }
+                        else if (Gizmo->GetGizmoType() == UGizmoBaseComponent::ArrowZ)
+                        {
+                            // 카메라의 위쪽 방향을 Z축 이동에 사용
+                            NewLocation.Z = Result.Z;
+                        }
+                    }
+                    else
+                    {
+                        // Result에서 현재 액터 위치를 빼서 이동 벡터를 구함
+                        const FVector Delta = Result - TargetComponent->GetWorldLocation();
+                        // 각 축에 대해 Local 방향 벡터에 투영하여 이동량 계산
+                        if (Gizmo->GetGizmoType() == UGizmoBaseComponent::ArrowX)
+                        {
+                            const float MoveAmount = FVector::DotProduct(Delta, TargetComponent->GetForwardVector());
+                            NewLocation += TargetComponent->GetForwardVector() * MoveAmount;
+                        }
+                        else if (Gizmo->GetGizmoType() == UGizmoBaseComponent::ArrowY)
+                        {
+                            const float MoveAmount = FVector::DotProduct(Delta, TargetComponent->GetRightVector());
+                            NewLocation += TargetComponent->GetRightVector() * MoveAmount;
+                            TargetComponent->SetWorldLocation(NewLocation);
+                        }
+                        else if (Gizmo->GetGizmoType() == UGizmoBaseComponent::ArrowZ)
+                        {
+                            const float MoveAmount = FVector::DotProduct(Delta, TargetComponent->GetUpVector());
+                            NewLocation += TargetComponent->GetUpVector() * MoveAmount;
+                        }
+                    }
+                    TargetComponent->SetWorldLocation(NewLocation);
                 }
             }
         }
-
         // 마우스 휠 이벤트
         else if (InMouseEvent.GetEffectingButton() == EKeys::MouseWheelAxis)
         {

--- a/EngineSIU/EngineSIU/Engine/Source/Editor/PropertyEditor/OutlinerEditorPanel.cpp
+++ b/EngineSIU/EngineSIU/Engine/Source/Editor/PropertyEditor/OutlinerEditorPanel.cpp
@@ -51,7 +51,8 @@ void OutlinerEditorPanel::Render()
             ImGuiTreeNodeFlags Flags = ImGuiTreeNodeFlags_None;
             if (InComp->GetAttachChildren().Num() == 0)
                 Flags |= ImGuiTreeNodeFlags_Leaf;
-
+        
+            ImGui::SetNextItemOpen(true, ImGuiCond_Always);
             bool NodeOpen = ImGui::TreeNodeEx(*Name, Flags);
 
             if (ImGui::IsItemClicked())
@@ -78,6 +79,7 @@ void OutlinerEditorPanel::Render()
 
         ImGuiTreeNodeFlags Flags = ImGuiTreeNodeFlags_None;
 
+        ImGui::SetNextItemOpen(true, ImGuiCond_Always);
         bool NodeOpen = ImGui::TreeNodeEx(*Actor->GetName(), Flags);
 
         if (ImGui::IsItemClicked())

--- a/EngineSIU/EngineSIU/Engine/Source/Runtime/Core/Math/MathUtility.h
+++ b/EngineSIU/EngineSIU/Engine/Source/Runtime/Core/Math/MathUtility.h
@@ -198,4 +198,15 @@ struct FMath
 		}
 		return A;
 	}
+
+    [[nodiscard]] static float Fmod(float X, float Y)
+	{
+	    const float AbsY = FMath::Abs(Y);
+	    if (AbsY <= SMALL_NUMBER)
+	    {
+	        return 0.0;
+	    }
+
+	    return fmodf(X, Y);
+	}
 };

--- a/EngineSIU/EngineSIU/Engine/Source/Runtime/Core/Math/Matrix.cpp
+++ b/EngineSIU/EngineSIU/Engine/Source/Runtime/Core/Math/Matrix.cpp
@@ -331,7 +331,59 @@ FMatrix FMatrix::GetRotationMatrix(const FQuat& InRotation)
     return Result;
 }
 
-FQuat FMatrix::ToQuat(const FMatrix& M) const
+FQuat FMatrix::ToQuat() const
 {
-    return FQuat(M);
+    return FQuat(*this);
+}
+
+FVector FMatrix::GetScaleVector(float Tolerance) const
+{
+    FVector Scale3D(1, 1, 1);
+
+    // For each row, find magnitude, and if its non-zero re-scale so its unit length.
+    for (int32 i = 0; i < 3; i++)
+    {
+        const float SquareSum = (M[i][0] * M[i][0]) + (M[i][1] * M[i][1]) + (M[i][2] * M[i][2]);
+        if (SquareSum > Tolerance)
+        {
+            Scale3D[i] = FMath::Sqrt(SquareSum);
+        }
+        else
+        {
+            Scale3D[i] = 0.f;
+        }
+    }
+
+    return Scale3D;
+}
+
+FVector FMatrix::GetTranslationVector() const
+{
+    return FVector(M[3][0], M[3][1], M[3][2]);
+}
+
+FMatrix FMatrix::GetMatrixWithoutScale(float Tolerance) const
+{
+    FMatrix Result = *this;
+    Result.RemoveScaling(Tolerance);
+    return Result;
+}
+
+void FMatrix::RemoveScaling(float Tolerance)
+{
+    const float SquareSum0 = (M[0][0] * M[0][0]) + (M[0][1] * M[0][1]) + (M[0][2] * M[0][2]);
+    const float SquareSum1 = (M[1][0] * M[1][0]) + (M[1][1] * M[1][1]) + (M[1][2] * M[1][2]);
+    const float SquareSum2 = (M[2][0] * M[2][0]) + (M[2][1] * M[2][1]) + (M[2][2] * M[2][2]);
+    const float Scale0 = (SquareSum0 - Tolerance) >= 0.f ? FMath::InvSqrt(SquareSum0) : 1.f;
+    const float Scale1 = (SquareSum1 - Tolerance) >= 0.f ? FMath::InvSqrt(SquareSum1) : 1.f;
+    const float Scale2 = (SquareSum2 - Tolerance) >= 0.f ? FMath::InvSqrt(SquareSum2) : 1.f;
+    M[0][0] *= Scale0;
+    M[0][1] *= Scale0;
+    M[0][2] *= Scale0;
+    M[1][0] *= Scale1;
+    M[1][1] *= Scale1;
+    M[1][2] *= Scale1;
+    M[2][0] *= Scale2;
+    M[2][1] *= Scale2;
+    M[2][2] *= Scale2;
 }

--- a/EngineSIU/EngineSIU/Engine/Source/Runtime/Core/Math/Matrix.h
+++ b/EngineSIU/EngineSIU/Engine/Source/Runtime/Core/Math/Matrix.h
@@ -45,7 +45,15 @@ public:
     static FMatrix GetRotationMatrix(const FRotator& InRotation);
     static FMatrix GetRotationMatrix(const FQuat& InRotation);
 
-    FQuat ToQuat(const FMatrix& M) const;
+    FQuat ToQuat() const;
+
+    FVector GetScaleVector(float Tolerance = SMALL_NUMBER) const;
+
+    FVector GetTranslationVector() const;
+
+    FMatrix GetMatrixWithoutScale(float Tolerance = SMALL_NUMBER) const;
+
+    void RemoveScaling(float Tolerance = SMALL_NUMBER);
 };
 
 inline FArchive& operator<<(FArchive& Ar, FMatrix& M)

--- a/EngineSIU/EngineSIU/Engine/Source/Runtime/Core/Math/Quat.cpp
+++ b/EngineSIU/EngineSIU/Engine/Source/Runtime/Core/Math/Quat.cpp
@@ -124,25 +124,63 @@ FQuat FQuat::CreateRotation(float roll, float pitch, float yaw)
 
 FMatrix FQuat::ToMatrix() const
 {
-    FMatrix RotationMatrix;
-    RotationMatrix.M[0][0] = 1.0f - 2.0f * (Y * Y + Z * Z);
-    RotationMatrix.M[0][1] = 2.0f * (X * Y - W * Z);
-    RotationMatrix.M[0][2] = 2.0f * (X * Z + W * Y);
-    RotationMatrix.M[0][3] = 0.0f;
+    FMatrix R;
+    const float x2 = X + X;    const float y2 = Y + Y;    const float z2 = Z + Z;
+    const float xx = X * x2;   const float xy = X * y2;   const float xz = X * z2;
+    const float yy = Y * y2;   const float yz = Y * z2;   const float zz = Z * z2;
+    const float wx = W * x2;   const float wy = W * y2;   const float wz = W * z2;
 
+    R.M[0][0] = 1.0f - (yy + zz);	R.M[1][0] = xy - wz;				R.M[2][0] = xz + wy;			R.M[3][0] = 0.0f;
+    R.M[0][1] = xy + wz;			R.M[1][1] = 1.0f - (xx + zz);		R.M[2][1] = yz - wx;			R.M[3][1] = 0.0f;
+    R.M[0][2] = xz - wy;			R.M[1][2] = yz + wx;				R.M[2][2] = 1.0f - (xx + yy);	R.M[3][2] = 0.0f;
+    R.M[0][3] = 0.0f;				R.M[1][3] = 0.0f;					R.M[2][3] = 0.0f;
 
-    RotationMatrix.M[1][0] = 2.0f * (X * Y + W * Z);
-    RotationMatrix.M[1][1] = 1.0f - 2.0f * (X * X + Z * Z);
-    RotationMatrix.M[1][2] = 2.0f * (Y * Z - W * X);
-    RotationMatrix.M[1][3] = 0.0f;
+    return R;
+}
 
-    RotationMatrix.M[2][0] = 2.0f * (X * Z - W * Y);
-    RotationMatrix.M[2][1] = 2.0f * (Y * Z + W * X);
-    RotationMatrix.M[2][2] = 1.0f - 2.0f * (X * X + Y * Y);
-    RotationMatrix.M[2][3] = 0.0f;
+bool FQuat::Equals(const FQuat& Q, float Tolerance) const
+{
+    return (FMath::Abs(X - Q.X) <= Tolerance && FMath::Abs(Y - Q.Y) <= Tolerance && FMath::Abs(Z - Q.Z) <= Tolerance && FMath::Abs(W - Q.W) <= Tolerance)
+        || (FMath::Abs(X + Q.X) <= Tolerance && FMath::Abs(Y + Q.Y) <= Tolerance && FMath::Abs(Z + Q.Z) <= Tolerance && FMath::Abs(W + Q.W) <= Tolerance);
+}
 
-    RotationMatrix.M[3][0] = RotationMatrix.M[3][1] = RotationMatrix.M[3][2] = 0.0f;
-    RotationMatrix.M[3][3] = 1.0f;
+FRotator FQuat::Rotator() const
+{
+    const float SingularityTest = Z * X - W * Y;
+    const float YawY = 2.f * (W * Z + X * Y);
+    const float YawX = (1.f - 2.f * (FMath::Square(Y) + FMath::Square(Z)));
 
-    return RotationMatrix;
+    // reference 
+    // http://en.wikipedia.org/wiki/Conversion_between_quaternions_and_Euler_angles
+    // http://www.euclideanspace.com/maths/geometry/rotations/conversions/quaternionToEuler/
+
+    // this value was found from experience, the above websites recommend different values
+    // but that isn't the case for us, so I went through different testing, and finally found the case 
+    // where both of world lives happily. 
+    const float SINGULARITY_THRESHOLD = 0.4999995f;
+    const float RAD_TO_DEG = (180.f / PI);
+    float Pitch, Yaw, Roll;
+
+    if (SingularityTest < -SINGULARITY_THRESHOLD)
+    {
+        Pitch = -90.f;
+        Yaw = (FMath::Atan2(YawY, YawX) * RAD_TO_DEG);
+        Roll = FRotator::NormalizeAxis(-Yaw - (2.f * FMath::Atan2(X, W) * RAD_TO_DEG));
+    }
+    else if (SingularityTest > SINGULARITY_THRESHOLD)
+    {
+        Pitch = 90.f;
+        Yaw = (FMath::Atan2(YawY, YawX) * RAD_TO_DEG);
+        Roll = FRotator::NormalizeAxis(Yaw - (2.f * FMath::Atan2(X, W) * RAD_TO_DEG));
+    }
+    else
+    {
+        Pitch = (FMath::Asin(2.f * SingularityTest) * RAD_TO_DEG);
+        Yaw = (FMath::Atan2(YawY, YawX) * RAD_TO_DEG);
+        Roll = (FMath::Atan2(-2.f * (W*X + Y*Z), (1.f - 2.f * (FMath::Square(X) + FMath::Square(Y)))) * RAD_TO_DEG);
+    }
+
+    FRotator RotatorFromQuat = FRotator(Pitch, Yaw, Roll);
+
+    return RotatorFromQuat;
 }

--- a/EngineSIU/EngineSIU/Engine/Source/Runtime/Core/Math/Quat.h
+++ b/EngineSIU/EngineSIU/Engine/Source/Runtime/Core/Math/Quat.h
@@ -1,4 +1,5 @@
 #pragma once
+#include "Rotator.h"
 #include "Serialization/Archive.h"
 
 struct FVector;
@@ -10,19 +11,19 @@ struct FQuat
     float W, X, Y, Z;
 
     // 기본 생성자
-    FQuat()
+    explicit FQuat()
         : W(1.0f), X(0.0f), Y(0.0f), Z(0.0f)
     {}
 
     // FQuat 생성자 추가: 회전 축과 각도를 받아서 FQuat 생성
-    FQuat(const FVector& Axis, float Angle);
+    explicit FQuat(const FVector& Axis, float Angle);
 
     // W, X, Y, Z 값으로 초기화
-    FQuat(float InW, float InX, float InY, float InZ)
+    explicit FQuat(float InW, float InX, float InY, float InZ)
         : W(InW), X(InX), Y(InY), Z(InZ)
     {}
 
-    FQuat(const FMatrix& InMatrix);
+    explicit FQuat(const FMatrix& InMatrix);
 
     // 쿼터니언의 곱셈 연산 (회전 결합)
     FQuat operator*(const FQuat& Other) const;
@@ -43,6 +44,10 @@ struct FQuat
 
     // 쿼터니언을 회전 행렬로 변환
     FMatrix ToMatrix() const;
+
+    bool Equals(const FQuat& Q, float Tolerance = KINDA_SMALL_NUMBER) const;
+
+    FRotator Rotator() const;
 };
 
 inline FArchive& operator<<(FArchive& Ar, FQuat& Q)

--- a/EngineSIU/EngineSIU/Engine/Source/Runtime/Core/Math/Rotator.cpp
+++ b/EngineSIU/EngineSIU/Engine/Source/Runtime/Core/Math/Rotator.cpp
@@ -12,39 +12,7 @@ FRotator::FRotator(const FVector& InVector)
 
 FRotator::FRotator(const FQuat& InQuat)
 {
-    const float SingularityTest = InQuat.Z * InQuat.X - InQuat.W * InQuat.Y;
-    const float YawY = 2.f * (InQuat.W * InQuat.Z + InQuat.X * InQuat.Y);
-    const float YawX = (1.f - 2.f * (FMath::Square(InQuat.Y) + FMath::Square(InQuat.Z)));
-
-    // reference 
-    // http://en.wikipedia.org/wiki/Conversion_between_quaternions_and_Euler_angles
-    // http://www.euclideanspace.com/maths/geometry/rotations/conversions/quaternionToEuler/
-
-    // this value was found from experience, the above websites recommend different values
-    // but that isn't the case for us, so I went through different testing, and finally found the case 
-    // where both of world lives happily. 
-    const float SINGULARITY_THRESHOLD = 0.4999995f;
-    const float RAD_TO_DEG = (180.f / PI);
-
-    if (SingularityTest < -SINGULARITY_THRESHOLD)
-    {
-        Pitch = -90.f;
-        Yaw = (FMath::Atan2(YawY, YawX) * RAD_TO_DEG);
-        Roll = (-Yaw - (2.f * atan2(InQuat.X, InQuat.W) * RAD_TO_DEG));
-    }
-    else if (SingularityTest > SINGULARITY_THRESHOLD)
-    {
-        Pitch = 90.f;
-        Yaw = (FMath::Atan2(YawY, YawX) * RAD_TO_DEG);
-        Roll = (Yaw - (2.f * FMath::Atan2(InQuat.X, InQuat.W) * RAD_TO_DEG));
-    }
-    else
-    {
-        Pitch = (asin(2.f * SingularityTest) * RAD_TO_DEG);
-        Yaw = (FMath::Atan2(YawY, YawX) * RAD_TO_DEG);
-        Roll = (FMath::Atan2(-2.f * (InQuat.W * InQuat.X + InQuat.Y * InQuat.Z),
-            (1.f - 2.f * (FMath::Square(InQuat.X) + FMath::Square(InQuat.Y)))) * RAD_TO_DEG);
-    }
+    *this = InQuat.Rotator();
 }
 
 FRotator FRotator::operator+(const FRotator& Other) const
@@ -60,7 +28,7 @@ FRotator& FRotator::operator+=(const FRotator& Other)
 
 FRotator FRotator::operator-(const FRotator& Other) const
 {
-    return { Pitch - Other.Pitch, Yaw - Other.Yaw, Roll - Other.Roll };
+    return FRotator{ Pitch - Other.Pitch, Yaw - Other.Yaw, Roll - Other.Roll };
 }
 
 FRotator& FRotator::operator-=(const FRotator& Other)
@@ -71,7 +39,7 @@ FRotator& FRotator::operator-=(const FRotator& Other)
 
 FRotator FRotator::operator*(float Scalar) const
 {
-    return { Pitch * Scalar, Yaw * Scalar, Roll * Scalar };
+    return FRotator{ Pitch * Scalar, Yaw * Scalar, Roll * Scalar };
 }
 
 FRotator& FRotator::operator*=(float Scalar)
@@ -82,12 +50,12 @@ FRotator& FRotator::operator*=(float Scalar)
 
 FRotator FRotator::operator/(const FRotator& Other) const
 {
-    return { Pitch / Other.Pitch, Yaw / Other.Yaw, Roll / Other.Roll };
+    return FRotator{ Pitch / Other.Pitch, Yaw / Other.Yaw, Roll / Other.Roll };
 }
 
 FRotator FRotator::operator/(float Scalar) const
 {
-    return { Pitch / Scalar, Yaw / Scalar, Roll / Scalar };
+    return FRotator{ Pitch / Scalar, Yaw / Scalar, Roll / Scalar };
 }
 
 FRotator& FRotator::operator/=(float Scalar)
@@ -98,7 +66,7 @@ FRotator& FRotator::operator/=(float Scalar)
 
 FRotator FRotator::operator-() const
 {
-    return { -Pitch, -Yaw, -Roll };
+    return FRotator{ -Pitch, -Yaw, -Roll };
 }
 
 bool FRotator::operator==(const FRotator& Other) const
@@ -140,13 +108,17 @@ FRotator FRotator::FromQuaternion(const FQuat& InQuat) const
 FQuat FRotator::ToQuaternion() const
 {
     float DegToRad = PI / 180.0f;
-    float Div =  DegToRad / 2.0f;
+    float Div = DegToRad / 2.0f;
     float SP, SY, SR;
     float CP, CY, CR;
 
-    FMath::SinCos(&SP, &CP, Pitch * Div);
-    FMath::SinCos(&SY, &CY, Yaw * Div);
-    FMath::SinCos(&SR, &CR, Roll * Div);
+    const float PitchNoWinding = FMath::Fmod(Pitch, 360.0f);
+    const float YawNoWinding = FMath::Fmod(Yaw, 360.0f);
+    const float RollNoWinding = FMath::Fmod(Roll, 360.0f);
+
+    FMath::SinCos(&SP, &CP, PitchNoWinding * Div);
+    FMath::SinCos(&SY, &CY, YawNoWinding * Div);
+    FMath::SinCos(&SR, &CR, RollNoWinding * Div);
 	
     FQuat RotationQuat;
     RotationQuat.X = CR * SP * SY - SR * CP * CY;
@@ -159,7 +131,20 @@ FQuat FRotator::ToQuaternion() const
 
 FVector FRotator::ToVector() const
 {
-    return FVector(FMath::DegreesToRadians(Roll), FMath::DegreesToRadians(Pitch), FMath::DegreesToRadians(Yaw));
+    const float PitchNoWinding = FMath::Fmod(Pitch, 360.f);
+    const float YawNoWinding = FMath::Fmod(Yaw, 360.f);
+
+    float CP, SP, CY, SY;
+    FMath::SinCos( &SP, &CP, FMath::DegreesToRadians(PitchNoWinding) );
+    FMath::SinCos( &SY, &CY, FMath::DegreesToRadians(YawNoWinding) );
+    FVector V = FVector( CP*CY, CP*SY, SP );
+
+    if (!_finite(V.X) || !_finite(V.Y) || !_finite(V.Z))
+    {
+        V = FVector::ForwardVector;
+    }
+
+    return V;
 }
 
 FVector FRotator::RotateVector(const FVector& Vec) const
@@ -172,9 +157,9 @@ FMatrix FRotator::ToMatrix() const
     return FMatrix::GetRotationMatrix(*this);
 }
 
-float FRotator::Clamp(float Angle) const
+float FRotator::ClampAxis(float Angle)
 {
-    Angle = std::fmod(Angle, 360.0f);
+    Angle = FMath::Fmod(Angle, 360.0f);
     if (Angle < 0.0f)
     {
         Angle += 360.0f;
@@ -184,7 +169,7 @@ float FRotator::Clamp(float Angle) const
 
 FRotator FRotator::GetNormalized() const
 {
-    return { FMath::UnwindDegrees(Pitch), FMath::UnwindDegrees(Yaw), FMath::UnwindDegrees(Roll) };
+    return FRotator{ FMath::UnwindDegrees(Pitch), FMath::UnwindDegrees(Yaw), FMath::UnwindDegrees(Roll) };
 }
 
 void FRotator::Normalize()
@@ -212,4 +197,15 @@ bool FRotator::InitFromString(const FString& InSourceString)
     return bSuccess;
 }
 
+float FRotator::NormalizeAxis(float Angle)
+{
+    Angle = ClampAxis(Angle);
 
+    if (Angle > 180.0f)
+    {
+        // shift to (-180,180]
+        Angle -= 360.0f;
+    }
+
+    return Angle;
+}

--- a/EngineSIU/EngineSIU/Engine/Source/Runtime/Core/Math/Rotator.h
+++ b/EngineSIU/EngineSIU/Engine/Source/Runtime/Core/Math/Rotator.h
@@ -14,11 +14,11 @@ struct FRotator
     float Yaw;
     float Roll;
 
-    FRotator()
+    explicit FRotator()
         : Pitch(0.0f), Yaw(0.0f), Roll(0.0f)
     {}
 
-    FRotator(float InPitch, float InYaw, float InRoll)
+    explicit FRotator(float InPitch, float InYaw, float InRoll)
         : Pitch(InPitch), Yaw(InYaw), Roll(InRoll)
     {}
 
@@ -26,8 +26,8 @@ struct FRotator
         : Pitch(Other.Pitch), Yaw(Other.Yaw), Roll(Other.Roll)
     {}
 
-    FRotator(const FVector& InVector);
-    FRotator(const FQuat& InQuat);
+    explicit FRotator(const FVector& InVector);
+    explicit FRotator(const FQuat& InQuat);
 
     FRotator operator+(const FRotator& Other) const;
     FRotator& operator+=(const FRotator& Other);
@@ -60,11 +60,12 @@ struct FRotator
     FVector RotateVector(const FVector& Vec) const;
     FMatrix ToMatrix() const;
 
-    float Clamp(float Angle) const;
+    static float ClampAxis(float Angle);
     FRotator GetNormalized() const;
     void Normalize();
-
     
     FString ToString() const;
     bool InitFromString(const FString& InSourceString);
+
+    static float NormalizeAxis(float Angle);
 };

--- a/EngineSIU/EngineSIU/Engine/Source/Runtime/Engine/Classes/Actors/Player.cpp
+++ b/EngineSIU/EngineSIU/Engine/Source/Runtime/Engine/Classes/Actors/Player.cpp
@@ -276,27 +276,25 @@ void AEditorPlayer::PickedObjControl()
     FEditorViewportClient* ActiveViewport = GEngineLoop.GetLevelEditor()->GetActiveViewportClient().get();
     if (Engine && Engine->GetSelectedActor() && ActiveViewport->GetPickedGizmoComponent())
     {
-        POINT currentMousePos;
-        GetCursorPos(&currentMousePos);
-        int32 deltaX = currentMousePos.x - m_LastMousePos.x;
-        int32 deltaY = currentMousePos.y - m_LastMousePos.y;
+        POINT CurrentMousePos;
+        GetCursorPos(&CurrentMousePos);
+        const float DeltaX = static_cast<float>(CurrentMousePos.x - m_LastMousePos.x);
+        const float DeltaY = static_cast<float>(CurrentMousePos.y - m_LastMousePos.y);
 
-        // USceneComponent* pObj = GetWorld()->GetPickingObj();
-        USceneComponent* SelectedComponent = Engine->GetSelectedComponent();
-        AActor* SelectedActor = Engine->GetSelectedActor();
-
-        USceneComponent* TargetComponent = nullptr;
-
-        if (SelectedComponent != nullptr)
+        USceneComponent* TargetComponent = Engine->GetSelectedComponent();
+        if (!TargetComponent)
         {
-            TargetComponent = SelectedComponent;
-        }
-        else if (SelectedActor != nullptr)
-        {
-            TargetComponent = SelectedActor->GetRootComponent();
+            if (AActor* SelectedActor = Engine->GetSelectedActor())
+            {
+                TargetComponent = SelectedActor->GetRootComponent();
+            }
+            else
+            {
+                return;
+            }
         }
         
-        UGizmoBaseComponent* Gizmo = static_cast<UGizmoBaseComponent*>(ActiveViewport->GetPickedGizmoComponent());
+        UGizmoBaseComponent* Gizmo = Cast<UGizmoBaseComponent>(ActiveViewport->GetPickedGizmoComponent());
         switch (ControlMode)
         {
         case CM_TRANSLATION:
@@ -304,16 +302,16 @@ void AEditorPlayer::PickedObjControl()
             // SLevelEditor에 있음
             break;
         case CM_SCALE:
-            ControlScale(TargetComponent, Gizmo, deltaX, deltaY);
+            ControlScale(TargetComponent, Gizmo, DeltaX, DeltaY);
 
             break;
         case CM_ROTATION:
-            ControlRotation(TargetComponent, Gizmo, deltaX, deltaY);
+            ControlRotation(TargetComponent, Gizmo, DeltaX, DeltaY);
             break;
         default:
             break;
         }
-        m_LastMousePos = currentMousePos;
+        m_LastMousePos = CurrentMousePos;
     }
 }
 
@@ -328,37 +326,51 @@ void AEditorPlayer::ControlRotation(USceneComponent* Component, UGizmoBaseCompon
     FVector CameraRight = ViewTransform->GetRightVector();
     FVector CameraUp = ViewTransform->GetUpVector();
 
-    FQuat currentRotation = Component->GetWorldRotation().ToQuaternion();
+    FQuat CurrentRotation = Component->GetWorldRotation().ToQuaternion();
 
-    FQuat rotationDelta;
+    FQuat RotationDelta = FQuat();
 
     if (Gizmo->GetGizmoType() == UGizmoBaseComponent::CircleX)
     {
-        float rotationAmount = (CameraUp.Z >= 0 ? -1.0f : 1.0f) * DeltaY * 0.01f;
-        rotationAmount = rotationAmount + (CameraRight.X >= 0 ? 1.0f : -1.0f) * DeltaX * 0.01f;
+        float RotationAmount = (CameraUp.Z >= 0 ? -1.0f : 1.0f) * DeltaY * 0.01f;
+        RotationAmount = RotationAmount + (CameraRight.X >= 0 ? 1.0f : -1.0f) * DeltaX * 0.01f;
 
-        rotationDelta = FQuat(FVector(1.0f, 0.0f, 0.0f), rotationAmount); // ���� X �� ���� ȸ��
+        FVector Axis = FVector::ForwardVector;
+        if (CoordMode == CDM_LOCAL)
+        {
+            Axis = Component->GetForwardVector();
+        }
+
+        RotationDelta = FQuat(Axis, RotationAmount);
     }
     else if (Gizmo->GetGizmoType() == UGizmoBaseComponent::CircleY)
     {
-        float rotationAmount = (CameraRight.X >= 0 ? 1.0f : -1.0f) * DeltaX * 0.01f;
-        rotationAmount = rotationAmount + (CameraUp.Z >= 0 ? 1.0f : -1.0f) * DeltaY * 0.01f;
+        float RotationAmount = (CameraRight.X >= 0 ? 1.0f : -1.0f) * DeltaX * 0.01f;
+        RotationAmount = RotationAmount + (CameraUp.Z >= 0 ? 1.0f : -1.0f) * DeltaY * 0.01f;
 
-        rotationDelta = FQuat(FVector(0.0f, 1.0f, 0.0f), rotationAmount); // ���� Y �� ���� ȸ��
+        FVector Axis = FVector::RightVector;
+        if (CoordMode == CDM_LOCAL)
+        {
+            Axis = Component->GetRightVector();
+        }
+
+        RotationDelta = FQuat(Axis, RotationAmount);
     }
     else if (Gizmo->GetGizmoType() == UGizmoBaseComponent::CircleZ)
     {
-        float rotationAmount = (CameraForward.X <= 0 ? -1.0f : 1.0f) * DeltaX * 0.01f;
-        rotationDelta = FQuat(FVector(0.0f, 0.0f, 1.0f), rotationAmount); // ���� Z �� ���� ȸ��
+        float RotationAmount = (CameraForward.X <= 0 ? -1.0f : 1.0f) * DeltaX * 0.01f;
+
+        FVector Axis = FVector::UpVector;
+        if (CoordMode == CDM_LOCAL)
+        {
+            Axis = Component->GetUpVector();
+        }
+
+        RotationDelta = FQuat(Axis, RotationAmount);
     }
-    if (CoordMode == CDM_LOCAL)
-    {
-        Component->SetRelativeRotation(currentRotation * rotationDelta);
-    }
-    else if (CoordMode == CDM_WORLD)
-    {
-        Component->SetRelativeRotation(rotationDelta * currentRotation);
-    }
+    
+    // 쿼터니언의 곱 순서는 delta * current 가 맞음.
+    Component->SetWorldRotation(RotationDelta * CurrentRotation); 
 }
 
 void AEditorPlayer::ControlScale(USceneComponent* Component, UGizmoBaseComponent* Gizmo, float DeltaX, float DeltaY)

--- a/EngineSIU/EngineSIU/Engine/Source/Runtime/Engine/Classes/Components/BillboardComponent.cpp
+++ b/EngineSIU/EngineSIU/Engine/Source/Runtime/Engine/Classes/Components/BillboardComponent.cpp
@@ -27,7 +27,7 @@ UObject* UBillboardComponent::Duplicate(UObject* InOuter)
         NewComponent->finalIndexV = finalIndexV;
         NewComponent->Texture = FEngineLoop::ResourceManager.GetTexture(TexturePath.ToWideString());
         NewComponent->TexturePath = TexturePath;
-        NewComponent->m_parent = m_parent;
+        NewComponent->UUIDParent = UUIDParent;
         NewComponent->bIsEditorBillboard = bIsEditorBillboard;
     }
     return NewComponent;
@@ -68,7 +68,7 @@ void UBillboardComponent::TickComponent(float DeltaTime)
     Super::TickComponent(DeltaTime);
 }
 
-int UBillboardComponent::CheckRayIntersection(FVector& rayOrigin, FVector& rayDirection, float& pfNearHitDistance)
+int UBillboardComponent::CheckRayIntersection(const FVector& InRayOrigin, const FVector& InRayDirection, float& OutHitDistance) const
 {
     TArray<FVector> Vertices =
     {
@@ -78,19 +78,19 @@ int UBillboardComponent::CheckRayIntersection(FVector& rayOrigin, FVector& rayDi
         FVector(-1.0f, -1.0f, 0.0f),
     };
 
-    return CheckPickingOnNDC(Vertices, pfNearHitDistance) ? 1 : 0;
+    return CheckPickingOnNDC(Vertices, OutHitDistance) ? 1 : 0;
 }
 
-void UBillboardComponent::SetTexture(const FWString& _fileName)
+void UBillboardComponent::SetTexture(const FWString& InFilePath)
 {
-    Texture = FEngineLoop::ResourceManager.GetTexture(_fileName);
-    TexturePath = FString(_fileName.c_str());
+    Texture = FEngineLoop::ResourceManager.GetTexture(InFilePath);
+    TexturePath = FString(InFilePath.c_str());
     //std::string str(_fileName.begin(), _fileName.end());
 }
 
-void UBillboardComponent::SetUUIDParent(USceneComponent* _parent)
+void UBillboardComponent::SetUUIDParent(USceneComponent* InUUIDParent)
 {
-    m_parent = _parent;
+    UUIDParent = InUUIDParent;
 }
 
 FMatrix UBillboardComponent::CreateBillboardMatrix() const
@@ -105,12 +105,16 @@ FMatrix UBillboardComponent::CreateBillboardMatrix() const
     CameraView.M[2][2] = -CameraView.M[2][2];
     FMatrix LookAtCamera = FMatrix::Transpose(CameraView);
 
-    FVector worldLocation = RelativeLocation;
-    if (m_parent)
-        worldLocation += m_parent->GetWorldLocation();
-    FVector worldScale = RelativeScale3D;
-    FMatrix S = FMatrix::CreateScaleMatrix(worldScale.X, worldScale.Y, worldScale.Z);
-    FMatrix T = FMatrix::CreateTranslationMatrix(worldLocation);
+    FVector WorldLocation = GetWorldLocation();
+    if (UUIDParent)
+    {
+        WorldLocation = UUIDParent->GetWorldLocation() + RelativeLocation;
+    }
+
+    FVector WorldScale = RelativeScale3D;
+    FMatrix S = FMatrix::CreateScaleMatrix(WorldScale.X, WorldScale.Y, WorldScale.Z);
+    FMatrix T = FMatrix::CreateTranslationMatrix(WorldLocation);
+
     // 최종 빌보드 행렬 = Scale * Rotation(LookAt) * Translation
     return S * LookAtCamera * T;
 }
@@ -118,6 +122,8 @@ FMatrix UBillboardComponent::CreateBillboardMatrix() const
 
 bool UBillboardComponent::CheckPickingOnNDC(const TArray<FVector>& quadVertices, float& hitDistance) const
 {
+    // TODO: 이 로직으로는 멀티 뷰포트에서 빌보드 피킹 안됨.
+
     // 마우스 위치를 클라이언트 좌표로 가져온 후 NDC 좌표로 변환
     POINT mousePos;
     GetCursorPos(&mousePos);
@@ -131,10 +137,11 @@ bool UBillboardComponent::CheckPickingOnNDC(const TArray<FVector>& quadVertices,
     float ndcX = (2.0f * mousePos.x / viewport.Width) - 1.0f;
     float ndcY = -((2.0f * mousePos.y / viewport.Height) - 1.0f);
 
+    std::shared_ptr<FEditorViewportClient> ActiveViewport = GEngineLoop.GetLevelEditor()->GetActiveViewportClient();
     // MVP 행렬 계산
     FMatrix M = CreateBillboardMatrix();
-    FMatrix V = GEngineLoop.GetLevelEditor()->GetActiveViewportClient()->GetViewMatrix();
-    FMatrix P = GEngineLoop.GetLevelEditor()->GetActiveViewportClient()->GetProjectionMatrix();
+    FMatrix V = ActiveViewport->GetViewMatrix();
+    FMatrix P = ActiveViewport->GetProjectionMatrix();
     FMatrix MVP = M * V * P;
 
     // quadVertices를 MVP로 변환하여 NDC 공간에서의 최소/최대값 구하기
@@ -161,8 +168,9 @@ bool UBillboardComponent::CheckPickingOnNDC(const TArray<FVector>& quadVertices,
     // 마우스 NDC 좌표가 quad의 NDC 경계 사각형 내에 있는지 검사
     if (ndcX >= minX && ndcX <= maxX && ndcY >= minY && ndcY <= maxY)
     {
-        // 임의로 hitDistance 설정 (필요 시 실제 깊이 계산)
-        hitDistance = 1000.0f;
+        const FVector WorldLocation = GetWorldLocation();
+        const FVector CameraLocation = ActiveViewport->GetCameraLocation();
+        hitDistance = (WorldLocation - CameraLocation).Length();
         return true;
     }
     return false;

--- a/EngineSIU/EngineSIU/Engine/Source/Runtime/Engine/Classes/Components/BillboardComponent.h
+++ b/EngineSIU/EngineSIU/Engine/Source/Runtime/Engine/Classes/Components/BillboardComponent.h
@@ -16,14 +16,10 @@ public:
     virtual void GetProperties(TMap<FString, FString>& OutProperties) const override;
     virtual void SetProperties(const TMap<FString, FString>& InProperties) override;
     virtual void TickComponent(float DeltaTime) override;
-    virtual int CheckRayIntersection(
-        FVector& rayOrigin,
-        FVector& rayDirection,
-        float& pfNearHitDistance
-    ) override;
+    virtual int CheckRayIntersection(const FVector& InRayOrigin, const FVector& InRayDirection, float& OutHitDistance) const override;
 
-    virtual void SetTexture(const FWString& _fileName);
-    void SetUUIDParent(USceneComponent* _parent);
+    virtual void SetTexture(const FWString& InFilePath);
+    void SetUUIDParent(USceneComponent* InUUIDParent);
     FMatrix CreateBillboardMatrix() const;
     FString GetTexturePath() const { return TexturePath; }
 
@@ -34,7 +30,7 @@ public:
     bool bIsEditorBillboard = false;
 
 protected:
-    USceneComponent* m_parent = nullptr;
+    USceneComponent* UUIDParent = nullptr;
     FString TexturePath = TEXT("default");
 
     // NDC 픽킹을 위한 내부 함수 : quadVertices는 월드 공간 정점 배열

--- a/EngineSIU/EngineSIU/Engine/Source/Runtime/Engine/Classes/Components/Light/LightComponent.cpp
+++ b/EngineSIU/EngineSIU/Engine/Source/Runtime/Engine/Classes/Components/Light/LightComponent.cpp
@@ -54,10 +54,9 @@ void ULightComponentBase::TickComponent(float DeltaTime)
     Super::TickComponent(DeltaTime);
 }
 
-int ULightComponentBase::CheckRayIntersection(FVector& rayOrigin, FVector& rayDirection, float& pfNearHitDistance)
+int ULightComponentBase::CheckRayIntersection(const FVector& InRayOrigin, const FVector& InRayDirection, float& OutHitDistance) const
 {
-    bool res = AABB.Intersect(rayOrigin, rayDirection, pfNearHitDistance);
-    return res;
+    return AABB.Intersect(InRayOrigin, InRayDirection, OutHitDistance);
 }
 
 void ULightComponentBase::UpdateViewMatrix()

--- a/EngineSIU/EngineSIU/Engine/Source/Runtime/Engine/Classes/Components/Light/LightComponent.h
+++ b/EngineSIU/EngineSIU/Engine/Source/Runtime/Engine/Classes/Components/Light/LightComponent.h
@@ -18,8 +18,8 @@ public:
     virtual void SetProperties(const TMap<FString, FString>& InProperties) override;
 
     virtual void TickComponent(float DeltaTime) override;
-    virtual int CheckRayIntersection(FVector& rayOrigin, FVector& rayDirection, float& pfNearHitDistance) override;
-
+    virtual int CheckRayIntersection(const FVector& InRayOrigin, const FVector& InRayDirection, float& OutHitDistance) const override;
+    
     virtual void UpdateViewMatrix();
     virtual void UpdateProjectionMatrix();
     

--- a/EngineSIU/EngineSIU/Engine/Source/Runtime/Engine/Classes/Components/Light/SpotLightComponent.cpp
+++ b/EngineSIU/EngineSIU/Engine/Source/Runtime/Engine/Classes/Components/Light/SpotLightComponent.cpp
@@ -103,9 +103,7 @@ void USpotLightComponent::SetProperties(const TMap<FString, FString>& InProperti
 
 FVector USpotLightComponent::GetDirection()
 {
-    FRotator rotator = GetWorldRotation();
-    FVector WorldForward = rotator.ToQuaternion().RotateVector(GetForwardVector());
-    return WorldForward;
+    return GetForwardVector();
 }
 
 FSpotLightInfo& USpotLightComponent::GetSpotLightInfo() 

--- a/EngineSIU/EngineSIU/Engine/Source/Runtime/Engine/Classes/Components/PrimitiveComponent.cpp
+++ b/EngineSIU/EngineSIU/Engine/Source/Runtime/Engine/Classes/Components/PrimitiveComponent.cpp
@@ -16,41 +16,38 @@ void UPrimitiveComponent::TickComponent(float DeltaTime)
     Super::TickComponent(DeltaTime);
 }
 
-int UPrimitiveComponent::CheckRayIntersection(FVector& rayOrigin, FVector& rayDirection, float& pfNearHitDistance)
+bool UPrimitiveComponent::IntersectRayTriangle(const FVector& RayOrigin, const FVector& RayDirection, const FVector& v0, const FVector& v1, const FVector& v2, float& OutHitDistance) const
 {
-    return 0;
-}
+    const FVector Edge1 = v1 - v0;
+    const FVector Edge2 = v2 - v0;
 
-bool UPrimitiveComponent::IntersectRayTriangle(const FVector& rayOrigin, const FVector& rayDirection,
-    const FVector& v0, const FVector& v1, const FVector& v2, float& hitDistance) const
-{
-    constexpr float epsilon = 1e-6f;
-    FVector edge1 = v1 - v0;
-    FVector edge2 = v2 - v0;
-    FVector h = rayDirection.Cross(edge2);
-    float a = edge1.Dot(h);
-
-    if (fabs(a) < epsilon)
-        return false;
-
+    FVector FrayDirection = RayDirection;
+    FVector h = FrayDirection.Cross(Edge2);
+    float a = Edge1.Dot(h);
+    
+    if (fabs(a) < SMALL_NUMBER)
+    {
+        return false; // Ray와 삼각형이 평행한 경우
+    }
     float f = 1.0f / a;
-    FVector s = rayOrigin - v0;
+    FVector s = RayOrigin - v0;
     float u = f * s.Dot(h);
     if (u < 0.0f || u > 1.0f)
-        return false;
-
-    FVector q = s.Cross(edge1);
-    float v = f * rayDirection.Dot(q);
-    if (v < 0.0f || (u + v) > 1.0f)
-        return false;
-
-    float t = f * edge2.Dot(q);
-    if (t > epsilon)
     {
-        hitDistance = t;
+        return false;
+    }
+    FVector q = s.Cross(Edge1);
+    float v = f * FrayDirection.Dot(q);
+    if (v < 0.0f || (u + v) > 1.0f)
+    {
+        return false;
+    }
+    float t = f * Edge2.Dot(q);
+    if (t > SMALL_NUMBER)
+    {
+        OutHitDistance = t;
         return true;
     }
-
     return false;
 }
 

--- a/EngineSIU/EngineSIU/Engine/Source/Runtime/Engine/Classes/Components/PrimitiveComponent.h
+++ b/EngineSIU/EngineSIU/Engine/Source/Runtime/Engine/Classes/Components/PrimitiveComponent.h
@@ -11,10 +11,8 @@ public:
 
     virtual UObject* Duplicate(UObject* InOuter) override;
     virtual void TickComponent(float DeltaTime) override;
-    virtual int CheckRayIntersection(FVector& rayOrigin, FVector& rayDirection, float& pfNearHitDistance) override;
 
-    bool IntersectRayTriangle(const FVector& rayOrigin, const FVector& rayDirection,
-        const FVector& v0, const FVector& v1, const FVector& v2, float& hitDistance) const;
+    bool IntersectRayTriangle(const FVector& RayOrigin, const FVector& RayDirection, const FVector& v0, const FVector& v1, const FVector& v2, float& OutHitDistance) const;
 
     void GetProperties(TMap<FString, FString>& OutProperties) const override;
     void SetProperties(const TMap<FString, FString>& InProperties) override;

--- a/EngineSIU/EngineSIU/Engine/Source/Runtime/Engine/Classes/Components/SceneComponent.cpp
+++ b/EngineSIU/EngineSIU/Engine/Source/Runtime/Engine/Classes/Components/SceneComponent.cpp
@@ -68,11 +68,9 @@ void USceneComponent::TickComponent(float DeltaTime)
 }
 
 
-int USceneComponent::CheckRayIntersection(FVector& InRayOrigin, FVector& InRayDirection, float& pfNearHitDistance)
+int USceneComponent::CheckRayIntersection(const FVector& InRayOrigin, const FVector& InRayDirection, float& OutHitDistance) const
 {
-    // TODO: 나중에 지워도 될듯
-    int nIntersections = 0;
-    return nIntersections;
+    return 0;
 }
 
 void USceneComponent::DestroyComponent(bool bPromoteChildren)
@@ -124,44 +122,43 @@ void USceneComponent::DestroyComponent(bool bPromoteChildren)
     Super::DestroyComponent(bPromoteChildren);
 }
 
-FVector USceneComponent::GetForwardVector()
+FVector USceneComponent::GetForwardVector() const
 {
-	FVector Forward = FVector(1.f, 0.f, 0.0f);
-	Forward = JungleMath::FVectorRotate(Forward, RelativeRotation);
+    FVector Forward = FVector::ForwardVector;
+    Forward = JungleMath::FVectorRotate(Forward, GetWorldRotation());
 	return Forward;
 }
 
-FVector USceneComponent::GetRightVector()
+FVector USceneComponent::GetRightVector() const
 {
-	FVector Right = FVector(0.f, 1.f, 0.0f);
-	Right = JungleMath::FVectorRotate(Right, RelativeRotation);
+    FVector Right = FVector::RightVector;
+    Right = JungleMath::FVectorRotate(Right, GetWorldRotation());
 	return Right;
 }
 
 FVector USceneComponent::GetUpVector() const
 {
-	FVector Up = FVector(0.f, 0.f, 1.0f);
-	Up = JungleMath::FVectorRotate(Up, RelativeRotation);
+    FVector Up = FVector::UpVector;
+    Up = JungleMath::FVectorRotate(Up, GetWorldRotation());
 	return Up;
 }
 
 
-void USceneComponent::AddLocation(FVector InAddValue)
+void USceneComponent::AddLocation(const FVector& InAddValue)
 {
 	RelativeLocation = RelativeLocation + InAddValue;
 
 }
 
-void USceneComponent::AddRotation(FVector InAddValue)
+void USceneComponent::AddRotation(const FRotator& InAddValue)
 {
 	RelativeRotation = RelativeRotation + InAddValue;
-
+    RelativeRotation.Normalize();
 }
 
-void USceneComponent::AddScale(FVector InAddValue)
+void USceneComponent::AddScale(const FVector& InAddValue)
 {
 	RelativeScale3D = RelativeScale3D + InAddValue;
-
 }
 
 void USceneComponent::AttachToComponent(USceneComponent* InParent)
@@ -202,82 +199,114 @@ void USceneComponent::DetachFromComponent(USceneComponent* Target)
     Target->AttachChildren.Remove(this);
 }
 
-FVector USceneComponent::GetWorldLocation() const
+void USceneComponent::SetRelativeRotation(const FRotator& InRotation)
 {
+    SetRelativeRotation(InRotation.ToQuaternion());
+}
+
+void USceneComponent::SetRelativeRotation(const FQuat& InQuat)
+{
+    FQuat NormalizedQuat = InQuat.Normalize();
+    RelativeRotation = NormalizedQuat.Rotator();
+    RelativeRotation.Normalize();
+}
+
+void USceneComponent::SetWorldLocation(const FVector& InLocation)
+{
+    // TODO: 코드 최적화 방법 생각하기
+    FMatrix NewRelativeMatrix = FMatrix::CreateTranslationMatrix(InLocation);
     if (AttachParent)
     {
-        return AttachParent->GetWorldLocation() + RelativeLocation;
+        FMatrix ParentMatrix = AttachParent->GetWorldMatrix().GetMatrixWithoutScale();
+        NewRelativeMatrix = NewRelativeMatrix * FMatrix::Inverse(ParentMatrix);
     }
-    return RelativeLocation;
+    FVector NewRelativeLocation = NewRelativeMatrix.GetTranslationVector();
+    RelativeLocation = NewRelativeLocation;
+}
+
+void USceneComponent::SetWorldRotation(const FRotator& InRotation)
+{
+    SetWorldRotation(InRotation.ToQuaternion());
+}
+
+void USceneComponent::SetWorldRotation(const FQuat& InQuat)
+{
+    // TODO: 코드 최적화 방법 생각하기
+    FMatrix NewRelativeMatrix = InQuat.ToMatrix();
+    if (AttachParent)
+    {
+        FMatrix ParentMatrix = AttachParent->GetWorldMatrix().GetMatrixWithoutScale();
+        NewRelativeMatrix = NewRelativeMatrix * FMatrix::Inverse(ParentMatrix);
+    }
+    FQuat NewRelativeRotation = FQuat(NewRelativeMatrix);
+    RelativeRotation = FRotator(NewRelativeRotation);
+    RelativeRotation.Normalize();   
+}
+
+void USceneComponent::SetWorldScale3D(const FVector& InScale)
+{
+    // TODO: 코드 최적화 방법 생각하기
+    FMatrix NewRelativeMatrix = FMatrix::CreateScaleMatrix(InScale.X, InScale.Y, InScale.Z);
+    if (AttachParent)
+    {
+        FMatrix ParentMatrix = FMatrix::GetScaleMatrix(AttachParent->RelativeScale3D);
+        NewRelativeMatrix = NewRelativeMatrix * FMatrix::Inverse(ParentMatrix);
+    }
+    FVector NewRelativeScale = NewRelativeMatrix.GetScaleVector();
+    RelativeScale3D = NewRelativeScale;
+}
+
+FVector USceneComponent::GetWorldLocation() const
+{
+    return GetWorldMatrix().GetTranslationVector();
 }
 
 FRotator USceneComponent::GetWorldRotation() const
 {
-    if (AttachParent)
-    {
-        return AttachParent->GetWorldRotation().ToQuaternion() * RelativeRotation.ToQuaternion();
-    }
-    return RelativeRotation;
+    FMatrix WorldMatrix = GetWorldMatrix().GetMatrixWithoutScale();
+    FQuat Quat = WorldMatrix.ToQuat();
+    return FRotator(Quat);
 }
 
 FVector USceneComponent::GetWorldScale3D() const
 {
-    if (AttachParent)
-    {
-        return AttachParent->GetWorldScale3D() * RelativeScale3D;
-    }
-    return RelativeScale3D;
+    return GetWorldMatrix().GetScaleVector();
 }
 
 FMatrix USceneComponent::GetScaleMatrix() const
 {
-    FMatrix ScaleMat = FMatrix::GetScaleMatrix(RelativeScale3D);
-    if (AttachParent)
-    {
-        FMatrix ParentScaleMat = AttachParent->GetScaleMatrix();
-        ScaleMat = ScaleMat * ParentScaleMat;
-    }
-    return ScaleMat;
+    return FMatrix::GetScaleMatrix(RelativeScale3D);
 }
 
 FMatrix USceneComponent::GetRotationMatrix() const
 {
-    FMatrix RotationMat = FMatrix::GetRotationMatrix(RelativeRotation);
-    if (AttachParent)
-    {
-        FMatrix ParentRotationMat = AttachParent->GetRotationMatrix();
-        RotationMat = RotationMat * ParentRotationMat;
-    }
-    return RotationMat;
+    return FMatrix::GetRotationMatrix(RelativeRotation);
 }
 
 FMatrix USceneComponent::GetTranslationMatrix() const
 {
-    FMatrix TranslationMat = FMatrix::GetTranslationMatrix(RelativeLocation);
-    if (AttachParent)
-    {
-        FMatrix ParentTranslationMat = AttachParent->GetTranslationMatrix();
-        TranslationMat = TranslationMat * ParentTranslationMat;
-    }
-    return TranslationMat;
+    return FMatrix::GetTranslationMatrix(RelativeLocation);
 }
 
 FMatrix USceneComponent::GetWorldMatrix() const
 {
-    FMatrix ScaleMat = FMatrix::GetScaleMatrix(RelativeScale3D);
-    FMatrix RotationMat = FMatrix::GetRotationMatrix(RelativeRotation);
-    FMatrix TranslationMat = FMatrix::GetTranslationMatrix(RelativeLocation);
+    FMatrix ScaleMat = GetScaleMatrix();
+    FMatrix RotationMat = GetRotationMatrix();
+    FMatrix TranslationMat = GetTranslationMatrix();
 
     FMatrix RTMat = RotationMat * TranslationMat;
-    if (AttachParent)
+    USceneComponent* Parent = AttachParent;
+    while (Parent)
     {
-        FMatrix ParentScaleMat = AttachParent->GetScaleMatrix();
-        FMatrix ParentRotationMat = AttachParent->GetRotationMatrix();
-        FMatrix ParentTranslationMat = AttachParent->GetTranslationMatrix();
+        FMatrix ParentScaleMat = Parent->GetScaleMatrix();
+        FMatrix ParentRotationMat = Parent->GetRotationMatrix();
+        FMatrix ParentTranslationMat = Parent->GetTranslationMatrix();
         
         ScaleMat = ScaleMat * ParentScaleMat;
         FMatrix ParentRTMat = ParentRotationMat * ParentTranslationMat;
         RTMat = RTMat * ParentRTMat;
+
+        Parent = Parent->AttachParent;
     }
     return ScaleMat * RTMat;
 }
@@ -304,15 +333,15 @@ FMatrix USceneComponent::GetWorldRTMatrix() const
 
 void USceneComponent::SetupAttachment(USceneComponent* InParent)
 {
-    if (
-        InParent != AttachParent                                  // 설정하려는 Parent가 기존의 Parent와 다르거나
+    if (InParent != AttachParent                                  // 설정하려는 Parent가 기존의 Parent와 다르거나
         && InParent != this                                       // InParent가 본인이 아니고
         && InParent != nullptr                                    // InParent가 유효한 포인터 이며
         && (
             AttachParent == nullptr                               // AttachParent도 유효하며
             || !AttachParent->AttachChildren.Contains(this)  // 한번이라도 SetupAttachment가 호출된적이 없는 경우
-        ) 
-    ) {
+            ) 
+        )
+    {
         AttachParent = InParent;
 
         // TODO: .AddUnique의 실행 위치를 RegisterComponent로 바꾸거나 해야할 듯

--- a/EngineSIU/EngineSIU/Engine/Source/Runtime/Engine/Classes/Components/SceneComponent.h
+++ b/EngineSIU/EngineSIU/Engine/Source/Runtime/Engine/Classes/Components/SceneComponent.h
@@ -17,16 +17,16 @@ public:
     void SetProperties(const TMap<FString, FString>& InProperties) override;
 
     virtual void TickComponent(float DeltaTime) override;
-    virtual int CheckRayIntersection(FVector& InRayOrigin, FVector& InRayDirection, float& pfNearHitDistance);
+    virtual int CheckRayIntersection(const FVector& InRayOrigin, const FVector& InRayDirection, float& OutHitDistance) const;
     virtual void DestroyComponent(bool bPromoteChildren = false) override;
 
-    virtual FVector GetForwardVector();
-    virtual FVector GetRightVector();
-    virtual FVector GetUpVector() const;
+    FVector GetForwardVector() const;
+    FVector GetRightVector() const;
+    FVector GetUpVector() const;
     
-    void AddLocation(FVector InAddValue);
-    void AddRotation(FVector InAddValue);
-    void AddScale(FVector InAddValue);
+    void AddLocation(const FVector& InAddValue);
+    void AddRotation(const FRotator& InAddValue);
+    void AddScale(const FVector& InAddValue);
 
     USceneComponent* GetAttachParent() const { return AttachParent; }
     const TArray<USceneComponent*>& GetAttachChildren() const { return AttachChildren; }
@@ -36,13 +36,19 @@ public:
     void DetachFromComponent(USceneComponent* Target);
 
 public:
-    void SetRelativeLocation(FVector InNewLocation) { RelativeLocation = InNewLocation; }
-    void SetRelativeRotation(FRotator InNewRotation) { RelativeRotation = InNewRotation; }
-    void SetRelativeScale3D(FVector NewScale) { RelativeScale3D = NewScale; }
+    void SetRelativeLocation(const FVector& InLocation) { RelativeLocation = InLocation; }
+    void SetRelativeRotation(const FRotator& InRotation);
+    void SetRelativeRotation(const FQuat& InQuat);
+    void SetRelativeScale3D(const FVector& InScale) { RelativeScale3D = InScale; }
     
     FVector GetRelativeLocation() const { return RelativeLocation; }
     FRotator GetRelativeRotation() const { return RelativeRotation; }
     FVector GetRelativeScale3D() const { return RelativeScale3D; }
+
+    void SetWorldLocation(const FVector& InLocation);
+    void SetWorldRotation(const FRotator& InRotation);
+    void SetWorldRotation(const FQuat& InQuat);
+    void SetWorldScale3D(const FVector& InScale);
 
     FVector GetWorldLocation() const;
     FRotator GetWorldRotation() const;

--- a/EngineSIU/EngineSIU/Engine/Source/Runtime/Engine/Classes/Components/StaticMeshComponent.cpp
+++ b/EngineSIU/EngineSIU/Engine/Source/Runtime/Engine/Classes/Components/StaticMeshComponent.cpp
@@ -11,7 +11,7 @@ UObject* UStaticMeshComponent::Duplicate(UObject* InOuter)
 {
     ThisClass* NewComponent = Cast<ThisClass>(Super::Duplicate(InOuter));
 
-    NewComponent->staticMesh = staticMesh;
+    NewComponent->StaticMesh = StaticMesh;
     NewComponent->selectedSubMeshIndex = selectedSubMeshIndex;
 
     return NewComponent;
@@ -85,23 +85,23 @@ void UStaticMeshComponent::SetProperties(const TMap<FString, FString>& InPropert
 
 uint32 UStaticMeshComponent::GetNumMaterials() const
 {
-    if (staticMesh == nullptr) return 0;
+    if (StaticMesh == nullptr) return 0;
 
-    return staticMesh->GetMaterials().Num();
+    return StaticMesh->GetMaterials().Num();
 }
 
 UMaterial* UStaticMeshComponent::GetMaterial(uint32 ElementIndex) const
 {
-    if (staticMesh != nullptr)
+    if (StaticMesh != nullptr)
     {
         if (OverrideMaterials[ElementIndex] != nullptr)
         {
             return OverrideMaterials[ElementIndex];
         }
     
-        if (staticMesh->GetMaterials().IsValidIndex(ElementIndex))
+        if (StaticMesh->GetMaterials().IsValidIndex(ElementIndex))
         {
-            return staticMesh->GetMaterials()[ElementIndex]->Material;
+            return StaticMesh->GetMaterials()[ElementIndex]->Material;
         }
     }
     return nullptr;
@@ -109,17 +109,17 @@ UMaterial* UStaticMeshComponent::GetMaterial(uint32 ElementIndex) const
 
 uint32 UStaticMeshComponent::GetMaterialIndex(FName MaterialSlotName) const
 {
-    if (staticMesh == nullptr) return -1;
+    if (StaticMesh == nullptr) return -1;
 
-    return staticMesh->GetMaterialIndex(MaterialSlotName);
+    return StaticMesh->GetMaterialIndex(MaterialSlotName);
 }
 
 TArray<FName> UStaticMeshComponent::GetMaterialSlotNames() const
 {
     TArray<FName> MaterialNames;
-    if (staticMesh == nullptr) return MaterialNames;
+    if (StaticMesh == nullptr) return MaterialNames;
 
-    for (const FStaticMaterial* Material : staticMesh->GetMaterials())
+    for (const FStaticMaterial* Material : StaticMesh->GetMaterials())
     {
         MaterialNames.Emplace(Material->MaterialSlotName);
     }
@@ -129,8 +129,8 @@ TArray<FName> UStaticMeshComponent::GetMaterialSlotNames() const
 
 void UStaticMeshComponent::GetUsedMaterials(TArray<UMaterial*>& Out) const
 {
-    if (staticMesh == nullptr) return;
-    staticMesh->GetUsedMaterials(Out);
+    if (StaticMesh == nullptr) return;
+    StaticMesh->GetUsedMaterials(Out);
     for (int materialIndex = 0; materialIndex < GetNumMaterials(); materialIndex++)
     {
         if (OverrideMaterials[materialIndex] != nullptr)
@@ -140,51 +140,59 @@ void UStaticMeshComponent::GetUsedMaterials(TArray<UMaterial*>& Out) const
     }
 }
 
-int UStaticMeshComponent::CheckRayIntersection(FVector& rayOrigin, FVector& rayDirection, float& pfNearHitDistance)
+int UStaticMeshComponent::CheckRayIntersection(const FVector& InRayOrigin, const FVector& InRayDirection, float& OutHitDistance) const
 {
-    if (!AABB.Intersect(rayOrigin, rayDirection, pfNearHitDistance)) return 0;
-    int nIntersections = 0;
-    if (staticMesh == nullptr) return 0;
+    if (!AABB.Intersect(InRayOrigin, InRayDirection, OutHitDistance))
+    {
+        return 0;
+    }
+    if (StaticMesh == nullptr)
+    {
+        return 0;
+    }
 
-    OBJ::FStaticMeshRenderData* renderData = staticMesh->GetRenderData();
+    OutHitDistance = FLT_MAX;
 
-    FStaticMeshVertex* vertices = renderData->Vertices.GetData();
-    int vCount = renderData->Vertices.Num();
-    UINT* indices = renderData->Indices.GetData();
-    int iCount = renderData->Indices.Num();
+    int IntersectionNum = 0;
 
-    if (!vertices) return 0;
-    BYTE* pbPositions = reinterpret_cast<BYTE*>(renderData->Vertices.GetData());
+    OBJ::FStaticMeshRenderData* RenderData = StaticMesh->GetRenderData();
+    const TArray<FStaticMeshVertex>& Vertices = RenderData->Vertices;
+    const int32 VertexNum = Vertices.Num();
+    if (VertexNum == 0)
+    {
+        return 0;
+    }
 
-    int nPrimitives = (!indices) ? (vCount / 3) : (iCount / 3);
-    float fNearHitDistance = FLT_MAX;
-    for (int i = 0; i < nPrimitives; i++) {
-        int idx0, idx1, idx2;
-        if (!indices) {
-            idx0 = i * 3;
-            idx1 = i * 3 + 1;
-            idx2 = i * 3 + 2;
-        }
-        else {
-            idx0 = indices[i * 3];
-            idx2 = indices[i * 3 + 1];
-            idx1 = indices[i * 3 + 2];
+    const TArray<UINT>& Indices = RenderData->Indices;
+    const int32 IndexNum = Indices.Num();
+    const bool bHasIndices = (IndexNum > 0);
+
+    int32 TriangleNum = bHasIndices ? (IndexNum / 3) : (VertexNum / 3);
+    for (int32 i = 0; i < TriangleNum; i++)
+    {
+        int32 Idx0 = i * 3;
+        int32 Idx1 = i * 3 + 1;
+        int32 Idx2 = i * 3 + 2;
+
+        if (bHasIndices)
+        {
+            Idx0 = Indices[Idx0];
+            Idx1 = Indices[Idx1];
+            Idx2 = Indices[Idx2];
         }
 
         // 각 삼각형의 버텍스 위치를 FVector로 불러옵니다.
-        uint32 stride = sizeof(FStaticMeshVertex);
-        FVector v0 = *reinterpret_cast<FVector*>(pbPositions + idx0 * stride);
-        FVector v1 = *reinterpret_cast<FVector*>(pbPositions + idx1 * stride);
-        FVector v2 = *reinterpret_cast<FVector*>(pbPositions + idx2 * stride);
+        FVector v0 = FVector(Vertices[Idx0].X, Vertices[Idx0].Y, Vertices[Idx0].Z);
+        FVector v1 = FVector(Vertices[Idx1].X, Vertices[Idx1].Y, Vertices[Idx1].Z);
+        FVector v2 = FVector(Vertices[Idx2].X, Vertices[Idx2].Y, Vertices[Idx2].Z);
 
-        float fHitDistance;
-        if (IntersectRayTriangle(rayOrigin, rayDirection, v0, v1, v2, fHitDistance)) {
-            if (fHitDistance < fNearHitDistance) {
-                pfNearHitDistance = fNearHitDistance = fHitDistance;
-            }
-            nIntersections++;
+        float HitDistance = FLT_MAX;
+        if (IntersectRayTriangle(InRayOrigin, InRayDirection, v0, v1, v2, HitDistance))
+        {
+            OutHitDistance = FMath::Min(HitDistance, OutHitDistance);
+            IntersectionNum++;
         }
 
     }
-    return nIntersections;
+    return IntersectionNum;
 }

--- a/EngineSIU/EngineSIU/Engine/Source/Runtime/Engine/Classes/Components/StaticMeshComponent.h
+++ b/EngineSIU/EngineSIU/Engine/Source/Runtime/Engine/Classes/Components/StaticMeshComponent.h
@@ -25,13 +25,13 @@ public:
     virtual TArray<FName> GetMaterialSlotNames() const override;
     virtual void GetUsedMaterials(TArray<UMaterial*>& Out) const override;
 
-    virtual int CheckRayIntersection(FVector& rayOrigin, FVector& rayDirection, float& pfNearHitDistance) override;
+    virtual int CheckRayIntersection(const FVector& InRayOrigin, const FVector& InRayDirection, float& OutHitDistance) const override;
     
-    UStaticMesh* GetStaticMesh() const { return staticMesh; }
+    UStaticMesh* GetStaticMesh() const { return StaticMesh; }
     void SetStaticMesh(UStaticMesh* value)
     { 
-        staticMesh = value;
-        if (staticMesh == nullptr)
+        StaticMesh = value;
+        if (StaticMesh == nullptr)
         {
             OverrideMaterials.SetNum(0);
             AABB = FBoundingBox(FVector::ZeroVector, FVector::ZeroVector);
@@ -39,11 +39,11 @@ public:
         else
         {
             OverrideMaterials.SetNum(value->GetMaterials().Num());
-            AABB = FBoundingBox(staticMesh->GetRenderData()->BoundingBoxMin, staticMesh->GetRenderData()->BoundingBoxMax);
+            AABB = FBoundingBox(StaticMesh->GetRenderData()->BoundingBoxMin, StaticMesh->GetRenderData()->BoundingBoxMax);
         }
     }
 
 protected:
-    UStaticMesh* staticMesh = nullptr;
+    UStaticMesh* StaticMesh = nullptr;
     int selectedSubMeshIndex = -1;
 };

--- a/EngineSIU/EngineSIU/Engine/Source/Runtime/Engine/Classes/Components/TextComponent.cpp
+++ b/EngineSIU/EngineSIU/Engine/Source/Runtime/Engine/Classes/Components/TextComponent.cpp
@@ -96,7 +96,7 @@ void UTextComponent::SetRowColumnCount(int cellsPerRow, int cellsPerColumn)
     ColumnCount = cellsPerColumn;
 }
 
-int UTextComponent::CheckRayIntersection(FVector& rayOrigin, FVector& rayDirection, float& pfNearHitDistance)
+int UTextComponent::CheckRayIntersection(const FVector& InRayOrigin, const FVector& InRayDirection, float& OutHitDistance) const
 {
     if (!(GEngineLoop.GetLevelEditor()->GetActiveViewportClient()->GetShowFlag() & static_cast<uint64>(EEngineShowFlags::SF_BillboardText)))
     {
@@ -119,7 +119,7 @@ int UTextComponent::CheckRayIntersection(FVector& rayOrigin, FVector& rayDirecti
         float hitDistance = 0.0f;
         if (CheckPickingOnNDC(LetterQuad, hitDistance))
         {
-            pfNearHitDistance = hitDistance;
+            OutHitDistance = hitDistance;
             return 1;
         }
     }

--- a/EngineSIU/EngineSIU/Engine/Source/Runtime/Engine/Classes/Components/TextComponent.h
+++ b/EngineSIU/EngineSIU/Engine/Source/Runtime/Engine/Classes/Components/TextComponent.h
@@ -28,8 +28,7 @@ public:
     
     void SetRowColumnCount(int cellsPerRow, int cellsPerColumn);
 
-    virtual int CheckRayIntersection(FVector& rayOrigin, FVector& rayDirection, float& pfNearHitDistance) override;
- 
+    virtual int CheckRayIntersection(const FVector& InRayOrigin, const FVector& InRayDirection, float& OutHitDistance) const override; 
     
     float GetRowCount() { return RowCount; }
     float GetColumnCount() { return ColumnCount; }

--- a/EngineSIU/EngineSIU/Engine/Source/Runtime/Engine/Classes/Components/UTextUUID.cpp
+++ b/EngineSIU/EngineSIU/Engine/Source/Runtime/Engine/Classes/Components/UTextUUID.cpp
@@ -6,7 +6,7 @@ UTextUUID::UTextUUID()
     SetRelativeLocation(FVector(0.0f, 0.0f, -0.5f));
 }
 
-int UTextUUID::CheckRayIntersection(FVector& rayOrigin, FVector& rayDirection, float& pfNearHitDistance)
+int UTextUUID::CheckRayIntersection(const FVector& InRayOrigin, const FVector& InRayDirection, float& OutHitDistance) const
 {
     return 0;
 }

--- a/EngineSIU/EngineSIU/Engine/Source/Runtime/Engine/Classes/Components/UTextUUID.h
+++ b/EngineSIU/EngineSIU/Engine/Source/Runtime/Engine/Classes/Components/UTextUUID.h
@@ -8,9 +8,6 @@ class UTextUUID : public UTextComponent
 public:
     UTextUUID();
 
-    virtual int CheckRayIntersection(
-        FVector& rayOrigin,
-        FVector& rayDirection, float& pfNearHitDistance
-    ) override;
+    virtual int CheckRayIntersection(const FVector& InRayOrigin, const FVector& InRayDirection, float& OutHitDistance) const override;
     void SetUUID(uint32 UUID);
 };

--- a/EngineSIU/EngineSIU/Engine/Source/Runtime/InteractiveToolsFramework/BaseGizmos/GizmoBaseComponent.cpp
+++ b/EngineSIU/EngineSIU/Engine/Source/Runtime/InteractiveToolsFramework/BaseGizmos/GizmoBaseComponent.cpp
@@ -5,53 +5,6 @@
 #include "LevelEditor/SLevelEditor.h"
 #include "UnrealEd/EditorViewportClient.h"
 
-
-int UGizmoBaseComponent::CheckRayIntersection(FVector& rayOrigin, FVector& rayDirection, float& pfNearHitDistance)
-{
-    int nIntersections = 0;
-    if (staticMesh == nullptr) return 0;
-    OBJ::FStaticMeshRenderData* renderData = staticMesh->GetRenderData();
-    FStaticMeshVertex* vertices = renderData->Vertices.GetData();
-    int vCount = renderData->Vertices.Num();
-    UINT* indices = renderData->Indices.GetData();
-    int iCount = renderData->Indices.Num();
-
-    if (!vertices) return 0;
-    BYTE* pbPositions = reinterpret_cast<BYTE*>(renderData->Vertices.GetData());
-
-    int nPrimitives = (!indices) ? (vCount / 3) : (iCount / 3);
-    float fNearHitDistance = FLT_MAX;
-    for (int i = 0; i < nPrimitives; i++) {
-        int idx0, idx1, idx2;
-        if (!indices) {
-            idx0 = i * 3;
-            idx1 = i * 3 + 1;
-            idx2 = i * 3 + 2;
-        }
-        else {
-            idx0 = indices[i * 3];
-            idx2 = indices[i * 3 + 1];
-            idx1 = indices[i * 3 + 2];
-        }
-
-        // 각 삼각형의 버텍스 위치를 FVector로 불러옵니다.
-        uint32 stride = sizeof(FStaticMeshVertex);
-        FVector v0 = *reinterpret_cast<FVector*>(pbPositions + idx0 * stride);
-        FVector v1 = *reinterpret_cast<FVector*>(pbPositions + idx1 * stride);
-        FVector v2 = *reinterpret_cast<FVector*>(pbPositions + idx2 * stride);
-
-        float fHitDistance;
-        if (IntersectRayTriangle(rayOrigin, rayDirection, v0, v1, v2, fHitDistance)) {
-            if (fHitDistance < fNearHitDistance) {
-                pfNearHitDistance = fNearHitDistance = fHitDistance;
-            }
-            nIntersections++;
-        }
-
-    }
-    return nIntersections;
-}
-
 void UGizmoBaseComponent::TickComponent(float DeltaTime)
 {
     Super::TickComponent(DeltaTime);

--- a/EngineSIU/EngineSIU/Engine/Source/Runtime/InteractiveToolsFramework/BaseGizmos/GizmoBaseComponent.h
+++ b/EngineSIU/EngineSIU/Engine/Source/Runtime/InteractiveToolsFramework/BaseGizmos/GizmoBaseComponent.h
@@ -23,8 +23,6 @@ public:
 public:
     UGizmoBaseComponent() = default;
 
-    virtual int CheckRayIntersection(FVector& rayOrigin, FVector& rayDirection, float& pfNearHitDistance) override;
-
     virtual void TickComponent(float DeltaTime) override;
 
 private:
@@ -35,5 +33,5 @@ public:
     
     void SetGizmoType(EGizmoType InGizmoType) { GizmoType = InGizmoType; }
 
-    float GizmoScale = 0.3f;
+    float GizmoScale = 0.2f;
 };

--- a/EngineSIU/EngineSIU/Engine/Source/Runtime/InteractiveToolsFramework/BaseGizmos/TransformGizmo.cpp
+++ b/EngineSIU/EngineSIU/Engine/Source/Runtime/InteractiveToolsFramework/BaseGizmos/TransformGizmo.cpp
@@ -96,6 +96,12 @@ void ATransformGizmo::Tick(float DeltaTime)
     {
         return;
     }
+
+    AEditorPlayer* EditorPlayer = Engine->GetEditorPlayer();
+    if (!EditorPlayer)
+    {
+        return;
+    }
     
     USceneComponent* SelectedComponent = Engine->GetSelectedComponent();
     AActor* SelectedActor = Engine->GetSelectedActor();
@@ -114,14 +120,14 @@ void ATransformGizmo::Tick(float DeltaTime)
     if (TargetComponent)
     {
         SetActorLocation(TargetComponent->GetWorldLocation());
-        if (Engine->GetEditorPlayer()->GetCoordMode() == ECoordMode::CDM_LOCAL)
+        if (EditorPlayer->GetCoordMode() == ECoordMode::CDM_LOCAL || EditorPlayer->GetControlMode() == EControlMode::CM_SCALE)
         {
             // TODO: 임시로 RootComponent의 정보로 사용
             SetActorRotation(TargetComponent->GetWorldRotation());
         }
-        else if (Engine->GetEditorPlayer()->GetCoordMode() == ECoordMode::CDM_WORLD)
+        else
         {
-            SetActorRotation(FVector(0.0f, 0.0f, 0.0f));
+            SetActorRotation(FRotator(0.0f, 0.0f, 0.0f));
         }
     }
 }


### PR DESCRIPTION
- 빌보드 피킹 로직 개선. 뒤에 다른 오브젝트가 있어도 가까이 있는 빌보드를 클릭하면 빌보드가 선택 됨.

- 컴포넌트의 월드 트랜스폼, 로컬 트랜스폼 계산 식 수정.

- FMatrix, FRotator, FQuat 의 수식들 수정.

- FVector, FRotator, FQuat의 생성자를 explicit으로 지정해서 잘못 적용하지 않게.

- 아웃라이너의 트리 노드가 항상 열려있게 개선.

- 스케일 기즈모는 항상 로컬 회전을 따름.

by Mstone8370 - https://github.com/cnh0728/GTL_W08_T6/pull/7